### PR TITLE
Fix of the color problem + reproducing the bug

### DIFF
--- a/backend/servers.py
+++ b/backend/servers.py
@@ -181,8 +181,8 @@ class Server(Redis):
                 return None
 
     def get_multiple_values(
-        self, *keys, prefix: Optional[str] = "", **kwargs
-    ) -> Tuple[List[Any], List[str]]:
+        self, *keys: str, prefix: Optional[str] = "", **kwargs
+    ) -> Tuple[Dict[str, Any], List[str]]:
         """
         Returns all the values corresponding the given keys. If key does not match any value, the key is returned
         explicitly tell that it is missing. An optional prefix can be added to every key.
@@ -192,18 +192,16 @@ class Server(Redis):
         :param prefix: the prefix to be added to each key
         :type prefix: Optional[str]
         :return: a tuple containing all values found and all keys which did not match
-        :rtype: Tuple[List[Any], List[str]]
+        :rtype: Tuple[Dict[str, Any], List[str]]
         """
-        values = []
+        values = dict()
         keys_not_found = []
 
         for key in keys:
             value = self.get_value(prefix + key, **kwargs)
             if value:
-                if isinstance(value, list):  # For course combo (list of courses)
-                    values.extend(value)
-                else:
-                    values.append(value)
+                # For course combo, a list of courses will be returned
+                values[key] = value
             else:
                 keys_not_found.append(key)
 


### PR DESCRIPTION
# In short

I think this solve the problem of the non-logical color ordering bug, i.e.: the color of the course does not match the order in which they were entered.

# Source of the problem

The problem come from the `manager.py:get_courses` function: the order of *codes* is not necessarily preserved since it first fetches in the Redis server, then fetches the missing values from the API. I proposed a fix which passes all tests but it is maybe not the best way to solver this :)

# How to reproduce

0. Make sure to try to reprod. this bug on another branch too
1. Launch a local ADE-Scheduler with redis-cli open
2. Add a first course, ex.: LEPL1104
3. Add a second course, ex: LEPL1105
4. Delete this second course in the ADE Interface, ex.: delete LEPL1105
5. Simulate the expiry of the first course with redis-cli: `del "[project_id=14]LEPL1104"`
6. Re-add the second course, ex.: LEPL1105

You should see that LEPL1105 takes the first color and LEPL1104 takes the second color.
