### PR TITLE
Python 3.6 to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Python version that is used in prod
 language: python
-python: "3.6"
+python: "3.8"
 
 # Cache install data
 cache:


### PR DESCRIPTION
Since the server runs on Python 3.8 (am I right ?), shouldn't we run the tests on Python 3.8 ?

This problems shows now since I upgraded the strong Python module and it requires Python >= 3.8.

Python 3.6 is now the oldest Python version alive and it may be good to not stick with this version :)