### PR TITLE
chore(deprecation): update compose commands to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         node-version: '16'
 
     - name: Docker compose up
-      run: docker-compose up -d
+      run: docker compose up -d
 
     - name: Bootstrap
       run: |


### PR DESCRIPTION
* Linked to deprecation of Docker Compose v1 in Github Actions: actions/runner-images#9692